### PR TITLE
Pol - ya no se puede reservar asientos duplicados, aun falta limitar la reserva de asientos a la cantidad de pasajes que esta comprando

### DIFF
--- a/client/components/PlantaAlta/PlantaAlta.tsx
+++ b/client/components/PlantaAlta/PlantaAlta.tsx
@@ -5,11 +5,13 @@ import { plantaAlta } from "../../assets/data";
 import { Passagers } from "@component/app/types/Passages";
 import PassengerModal from "../modalPasajeros/ModalPasajeros";
 
-const PlantaAltaAdmin: React.FC<Passagers> = ({ enabledSeats, passangers }) => {
+const PlantaAlta: React.FC<Passagers> = ({ enabledSeats, passangers }) => {
   const [seatEnabled, setSeatEnabled] = useState<boolean[]>([]);
   const [selectedSeat, setSelectedSeat] = useState<string>("");
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [remainingPassengers, setRemainingPassengers] = useState(passangers);
+  const [selectedSeats, setSelectedSeats] = useState<string[]>([]);
+  const [occupiedSeats, setOccupiedSeats] = useState<string[]>([]);
 
   const handleSeatToggle = (seatIndex: number) => {
     setSeatEnabled((prevSeats) => {
@@ -22,10 +24,12 @@ const PlantaAltaAdmin: React.FC<Passagers> = ({ enabledSeats, passangers }) => {
   console.log(passangers);
 
   const handleSeatSelection = (seat: string) => {
-    if (!isSeatEnabled(plantaAlta.indexOf(seat))) {
-      return; // Skip opening the modal for disabled seats
+    if (!isSeatEnabled(plantaAlta.indexOf(seat)) || selectedSeats.includes(seat)) {
+      return; // Skip opening the modal for disabled seats or already selected seats
     }
+
     setSelectedSeat(seat);
+    setSelectedSeats((prevSelectedSeats) => [...prevSelectedSeats, seat]);
 
     setIsModalOpen(true);
   };
@@ -41,7 +45,7 @@ const PlantaAltaAdmin: React.FC<Passagers> = ({ enabledSeats, passangers }) => {
   const numberSeat = enabledSeats?.numberSeat ?? [];
   const isSeatEnabled = (index: number) => {
     const seat = plantaAlta[index];
-    return numberSeat.includes(seat);
+    return numberSeat.includes(seat) && !occupiedSeats.includes(seat);
   };
 
   if (!enabledSeats) {
@@ -67,7 +71,7 @@ const PlantaAltaAdmin: React.FC<Passagers> = ({ enabledSeats, passangers }) => {
               <label
                 className={`cursor-pointer ${
                   seatEnabled[index] ? "hover:bg-blue-200" : "cursor-not-allowed"
-                }`}
+                } ${selectedSeats.includes(seat) ? "bg-blue-500" : ""}`}
                 htmlFor={`checkbox-${seat}`}
                 onClick={() => handleSeatSelection(seat)}
               >
@@ -87,11 +91,10 @@ const PlantaAltaAdmin: React.FC<Passagers> = ({ enabledSeats, passangers }) => {
           setIsModalOpen={setIsModalOpen}
           isModalOpen={isModalOpen}
           seat={selectedSeat}
-        
         />
       )}
     </div>
   );
 };
 
-export default PlantaAltaAdmin;
+export default PlantaAlta;

--- a/client/components/modalPasajeros/ModalPasajeros.tsx
+++ b/client/components/modalPasajeros/ModalPasajeros.tsx
@@ -8,7 +8,6 @@ const ModalPasajeros: React.FC<PassengerFormModalProps> = ({
   setIsModalOpen,
   seat,
   enabledSeats,
-  
 }) => {
   const [formData, setFormData] = useState<PassengerFormData>({
     nombre: "",
@@ -32,6 +31,10 @@ const ModalPasajeros: React.FC<PassengerFormModalProps> = ({
     }));
   };
 
+  // Elimina la línea de importación de sessionStorage
+
+  // ...
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     // Perform form validation here
@@ -48,8 +51,16 @@ const ModalPasajeros: React.FC<PassengerFormModalProps> = ({
     // Save updated passenger data to sessionStorage
     sessionStorage.setItem("passengerData", JSON.stringify(updatedPassengerData));
 
-    setIsModalOpen(false); //
-    // Pass the form data to the parent component
+    // Mark the selected seat as occupied
+    const updatedEnabledSeats = {
+      ...enabledSeats,
+      numberSeat: [...enabledSeats.numberSeat, seat],
+    };
+
+    // Pass the updated enabled seats back to the parent component
+    // You may need to define a prop to pass the function to update the enabled seats
+
+    setIsModalOpen(false); // Close the modal
 
     // Reset the form data
     setFormData({
@@ -66,6 +77,8 @@ const ModalPasajeros: React.FC<PassengerFormModalProps> = ({
       quantity: "",
     });
   };
+
+  // ...
 
   // console.log(`a${enabledSeats?.numberSeat}`);
   const handleCloseModal = () => {


### PR DESCRIPTION
update, ya no se puede reservar 2 veces el mismo asiento, una vez que lo reservaste, falta que cambie al color azul para indicarle esto al cliente, y lograr que solo te permita limitar al usuario a reservar los asientos que se indiquen en el contador, por ahora puede reservar infinitos mientras esten enabled